### PR TITLE
fix broken dependencies go-kafka-connect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.12.1
-	github.com/ricardo-ch/go-kafka-connect v0.0.0-20190603085745-132b7b7ad380a6c860fecc0ca9b0a2af9bf45471
+	github.com/ricardo-ch/go-kafka-connect v0.0.0-20180209135343-132b7b7ad380
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/ricardo-ch/go-kafka-connect v0.0.0-20180209135343-132b7b7ad380 h1:aNtFBX/AQJdXmUFDS8kqzIsnh9uFslENHCjP+7VxMQo=
+github.com/ricardo-ch/go-kafka-connect v0.0.0-20180209135343-132b7b7ad380/go.mod h1:1wqdL63J2nVaqWpJuc1SH1nc+yuEYZrYI6JpxGhY3F4=
 github.com/ricardo-ch/go-kafka-connect v0.0.0-20190603085745-132b7b7ad380a6c860fecc0ca9b0a2af9bf45471 h1:72zdRhATkqj0AF2EgQpXK3rL77+hGy7rGNmzHNDXB7U=
 github.com/ricardo-ch/go-kafka-connect v0.0.0-20190603085745-132b7b7ad380a6c860fecc0ca9b0a2af9bf45471/go.mod h1:1wqdL63J2nVaqWpJuc1SH1nc+yuEYZrYI6JpxGhY3F4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=


### PR DESCRIPTION
When trying to build I get the following dependency error, this commit resolves this

`go: github.com/ricardo-ch/go-kafka-connect@v0.0.0-20190603085745-132b7b7ad380a6c860fecc0ca9b0a2af9bf45471: invalid pseudo-version: revision is longer than canonical (132b7b7ad380)`