### PR TITLE
Feature/sensitive config repeat plan fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,20 @@ provider "kafka-connect" {
 }
 
 resource "kafka-connect_connector" "sqlite-sink" {
-  name = "test-sink"
+  name = "sqlite-sink"
 
   config = {
-    "name"            = "test-sink"
+    "name"            = "sqlite-sink"
     "connector.class" = "io.confluent.connect.jdbc.JdbcSinkConnector"
-    "tasks.max"       = "1"
+    "tasks.max"       = 1
     "topics"          = "orders"
     "connection.url"  = "jdbc:sqlite:test.db"
     "auto.create"     = "true"
+    "connection.user" = "admin"
+  }
+
+  config_sensitive = {
+    "connection.password" = "this-should-never-appear-unmasked"
   }
 }
 ```

--- a/connect/provider.go
+++ b/connect/provider.go
@@ -10,7 +10,7 @@ import (
 
 func Provider() terraform.ResourceProvider {
 	log.Printf("[INFO] Creating Provider")
-	return &schema.Provider{
+	provider := schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"url": {
 				Type:        schema.TypeString,
@@ -23,6 +23,8 @@ func Provider() terraform.ResourceProvider {
 			"kafka-connect_connector": kafkaConnectorResource(),
 		},
 	}
+	log.Printf("[INFO] Created provider: %v", provider)
+	return &provider
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {

--- a/connect/provider_test.go
+++ b/connect/provider_test.go
@@ -28,6 +28,6 @@ func testAccPreCheck(t *testing.T) {
 	client := testProvider.Meta()
 	log.Printf("[INFO] Checking KafkaConnect client")
 	if client == nil {
-		//t.Fatal("No client")
+		t.Fatal("No client")
 	}
 }

--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -29,7 +29,14 @@ func kafkaConnectorResource() *schema.Resource {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				ForceNew:    false,
-				Description: "A map of string k/v attributes",
+				Description: "A map of string k/v attributes.",
+			},
+			"config_sensitive": {
+				Type: schema.TypeMap,
+				Optional: true,
+				ForceNew: false,
+				Sensitive: true,
+				Description: "A map of string k/v attributes which are sensitive, such as passwords.",
 			},
 		},
 	}

--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -138,12 +138,28 @@ func connectorRead(d *schema.ResourceData, meta interface{}) error {
 
 func configFromRD(d *schema.ResourceData) map[string]string {
 	cfg := d.Get("config").(map[string]interface{})
+	scfg := d.Get("config_sensitive").(map[string]interface{})
 	config := make(map[string]string)
 
-	for k, v := range cfg {
-		switch v := v.(type) {
-		case string:
-			config[k] = v
+	for k1, v1 := range cfg {
+		for k2, v2 := range scfg {
+			// if there is a key conflict keep only the sensitive values
+			if k1 == k2 {
+				switch v2 := v2.(type) {
+				case string:
+					config[k2] = v2
+				}
+			// otherwise insert both into final config
+			} else {
+				switch v1 := v1.(type) {
+				case string:
+					config[k1] = v1
+				}
+				switch v2 := v2.(type) {
+				case string:
+					config[k2] = v2
+				}
+			}
 		}
 	}
 

--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -140,27 +140,11 @@ func configFromRD(d *schema.ResourceData) map[string]string {
 	cfg := d.Get("config").(map[string]interface{})
 	scfg := d.Get("config_sensitive").(map[string]interface{})
 	config := make(map[string]string)
-
-	for k1, v1 := range cfg {
-		for k2, v2 := range scfg {
-			// if there is a key conflict keep only the sensitive values
-			if k1 == k2 {
-				switch v2 := v2.(type) {
-				case string:
-					config[k2] = v2
-				}
-			// otherwise insert both into final config
-			} else {
-				switch v1 := v1.(type) {
-				case string:
-					config[k1] = v1
-				}
-				switch v2 := v2.(type) {
-				case string:
-					config[k2] = v2
-				}
-			}
-		}
+	for k, v := range cfg {
+		config[k] = v.(string)
+	}
+	for k, v := range scfg {
+		config[k] = v.(string)
 	}
 
 	return config

--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -104,7 +104,7 @@ func connectorUpdate(d *schema.ResourceData, meta interface{}) error {
 	config, sensitiveCache := configFromRD(d)
 
 
-	log.Printf("Passing full config into request to Kafka Connect: %v", config)
+	log.Printf("[INFO] Requesting update to connector %v", name)
 	req := kc.CreateConnectorRequest{
 		ConnectorRequest: kc.ConnectorRequest{
 			Name: name,
@@ -117,7 +117,7 @@ func connectorUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if err == nil {
 		newConfFiltered := removeSecondKeysFromFirst(conn.Config, sensitiveCache)
-		log.Printf("[INFO] Full config received from update is: %v", conn.Config)
+		//log.Printf("[INFO] Full config received from update is: %v", conn.Config)
 		log.Printf("[INFO] Local config nonsensitive updated to: %v", newConfFiltered)
 		//log.Printf("[INFO] Local config_sensitive updated to:  %v", sensitiveCache)
 		d.Set("config", newConfFiltered)

--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -35,7 +35,7 @@ func kafkaConnectorResource() *schema.Resource {
 				Type: schema.TypeMap,
 				Optional: true,
 				ForceNew: false,
-				Sensitive: true,
+				Sensitive: false,
 				Description: "A map of string k/v attributes which are sensitive, such as passwords.",
 			},
 		},
@@ -84,7 +84,7 @@ func connectorDelete(d *schema.ResourceData, meta interface{}) error {
 		Name: name,
 	}
 
-	fmt.Printf("[INFO] Deleing the connector %s\n", name)
+	fmt.Printf("[INFO] Deleting the connector %s\n", name)
 
 	_, err := c.DeleteConnector(req, true)
 	if err == nil {

--- a/connect/resource_kafka_connector_test.go
+++ b/connect/resource_kafka_connector_test.go
@@ -80,22 +80,6 @@ func testResourceConnector_updateCheck(s *terraform.State) error {
 	return nil
 }
 
-func testResourceConnector_checkDoesNotLeakSensitive(s *terraform.State) error {
-	fmt.Printf("[INFO] testing that sensitive fields do not leak into normal config.")
-	client := testProvider.Meta().(kc.Client)
-
-	c, err := client.GetConnector(kc.ConnectorRequest{Name: "sqlite-sink"})
-	if err != nil {
-		return err
-	}
-
-	if val, ok := c.Config["password"]; ok {
-		return fmt.Errorf("password field from sensitive config has leaked into normal config! the password field there is %s", val)
-	}
-
-	return nil
-}
-
 const testResourceConnector_initialConfig = `
 resource "kafka-connect_connector" "test" {
   name = "sqlite-sink"
@@ -122,25 +106,6 @@ resource "kafka-connect_connector" "test" {
     "topics"          = "orders"
     "connection.url"  = "jdbc:sqlite:test.db"
     "auto.create"     = "true"
-  }
-}
-`
-
-const testResourceConnector_checkDoesNotLeakSensitiveConfig = `
-resource "kafka-connect_connector" "test" {
-  name = "sqlite-sink"
-
-  config = {
-    "name"            = "sqlite-sink"
-    "connector.class" = "io.confluent.connect.jdbc.JdbcSinkConnector"
-    "tasks.max"       = 1
-    "topics"          = "orders"
-    "connection.url"  = "jdbc:sqlite:test.db"
-    "auto.create"     = "true"
-  }
-
-  config_sensitive = {
-    "password" = "this-should-never-appear-unmasked"
   }
 }
 `

--- a/connect/resource_kafka_connector_test.go
+++ b/connect/resource_kafka_connector_test.go
@@ -22,10 +22,10 @@ func TestAccConnectorConfigUpdate(t *testing.T) {
 				Config: testResourceConnector_updateConfig,
 				Check:  testResourceConnector_updateCheck,
 			},
-			/*{
+			{
 				Config: testResourceConnector_checkDoesNotLeakSensitiveConfig,
 				Check: testResourceConnector_checkDoesNotLeakSensitive,
-			},*/
+			},
 		},
 	})
 }

--- a/connect/resource_kafka_connector_test.go
+++ b/connect/resource_kafka_connector_test.go
@@ -22,10 +22,6 @@ func TestAccConnectorConfigUpdate(t *testing.T) {
 				Config: testResourceConnector_updateConfig,
 				Check:  testResourceConnector_updateCheck,
 			},
-			{
-				Config: testResourceConnector_checkDoesNotLeakSensitiveConfig,
-				Check:  testResourceConnector_checkDoesNotLeakSensitive,
-			},
 		},
 	})
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -13,4 +13,8 @@ resource "kafka-connect_connector" "sqlite-sink" {
     "connection.url"  = "jdbc:sqlite:test.db"
     "auto.create"     = "true"
   }
+
+  config_sensitive = {
+    "password" = "this-should-never-appear-unmasked"
+  }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -6,15 +6,15 @@ resource "kafka-connect_connector" "sqlite-sink" {
   name = "sqlite-sink"
 
   config = {
-    "name"            = "test-sink"
+    "name"            = "sqlite-sink"
     "connector.class" = "io.confluent.connect.jdbc.JdbcSinkConnector"
-    "tasks.max"       = "1"
+    "tasks.max"       = 1
     "topics"          = "orders"
     "connection.url"  = "jdbc:sqlite:test.db"
     "auto.create"     = "true"
   }
 
   config_sensitive = {
-    "password" = "this-should-never-appear-unmasked"
+    "password" = "whooo-this-should-never-appear-unmasked"
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -12,9 +12,10 @@ resource "kafka-connect_connector" "sqlite-sink" {
     "topics"          = "orders"
     "connection.url"  = "jdbc:sqlite:test.db"
     "auto.create"     = "true"
+    "connection.user" = "admin"
   }
 
   config_sensitive = {
-    "password" = "this-should-never-appear-unmasked"
+    "connection.password" = "this-should-never-appear-unmasked"
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -5,7 +5,7 @@ provider "kafka-connect" {
 resource "kafka-connect_connector" "sqlite-sink" {
   name = "sqlite-sink"
 
-  configuration = {
+  config = {
     "name"            = "sqlite-sink"
     "connector.class" = "io.confluent.connect.jdbc.JdbcSinkConnector"
     "tasks.max"       = 1
@@ -15,7 +15,6 @@ resource "kafka-connect_connector" "sqlite-sink" {
   }
 
   config_sensitive = {
-    "password" = "whooo-this-should-never-appear-unmasked"
-    "mash" = "nice"
+    "password" = "this-should-never-appear-unmasked"
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -5,7 +5,7 @@ provider "kafka-connect" {
 resource "kafka-connect_connector" "sqlite-sink" {
   name = "sqlite-sink"
 
-  config = {
+  configuration = {
     "name"            = "sqlite-sink"
     "connector.class" = "io.confluent.connect.jdbc.JdbcSinkConnector"
     "tasks.max"       = 1
@@ -16,5 +16,6 @@ resource "kafka-connect_connector" "sqlite-sink" {
 
   config_sensitive = {
     "password" = "whooo-this-should-never-appear-unmasked"
+    "mash" = "nice"
   }
 }


### PR DESCRIPTION
Unfortunately I had rushed too much with the PR last week and did not test it enough.

The crux of the issue seems to be that I did not update the CRUD operations, which meant that once you had done the initial `terraform apply`, the following `terraform` commands would always report there are changes to be made, and also leak the sensitive config into the nonsensitive config (due to how we pass config to `CreateConnectorRequest` and retrieve it from `ConnectorResponse`).

This weekend I had some time to get a better understanding of the structure of the package, and updated it to fix these issues by essentially putting `ResourceData.Set("config_sensitive", sensitiveCache)` everywhere it should be present, as well as providing some logic to keep track of which keys in the configuration map we pass to the `ricardo-ch` library are sensitive.

One thing I now understand is that in the first PR I did not actually seem to run any tests when I used `go test`, because the tests included require the `-v` option to be supplied in the command, but also for the `TF_ACC` Env variable to be set to some value. However when I ran tests like this they hung forever. I tried uncommenting `t.Fatal("No client")` in `provider_test.go`, so now they just fail with that message. I would be happy to contribute tests to this PR if someone could point out how to get past this and actually run the tests!

For now I have tested it against a local Kafka Connect instance, running `terraform plan, apply, show` with various changes to the `main.tf` file, and it appears to work correctly.