### PR TITLE
Fix connector import

### DIFF
--- a/connect/resource_kafka_connector_test.go
+++ b/connect/resource_kafka_connector_test.go
@@ -19,6 +19,12 @@ func TestAccConnectorConfigUpdate(t *testing.T) {
 				Check:  testResourceConnector_initialCheck,
 			},
 			{
+				Config:            testResourceConnector_initialConfig,
+				ResourceName:      "kafka-connect_connector.test",
+				ImportStateVerify: true,
+				ImportState:       true,
+			},
+			{
 				Config: testResourceConnector_updateConfig,
 				Check:  testResourceConnector_updateCheck,
 			},


### PR DESCRIPTION
I think that should fix https://github.com/Mongey/terraform-provider-kafka-connect/issues/13 but I am not a go or a terraform expert and there a couple things I noticed that might be problems:

- if the actual config and the one in the the local terraform don't match it's going to succeed and then suggest the changes on the next apply which I am not sure is the behaviour we want
- It's also going to ignore `config_sensitive` which I think is fine as this is not something provided by kafka-connect
- I have also changed the signature of some of the functions to match what I saw in https://www.terraform.io/docs/extend/writing-custom-providers.html#defining-resources as it seemed reasonable and gave more meaningful errors when it was crashing initially