### PR TITLE
connectorCreate() can return error when there is and it shouldn't proceed to connectorRead which returns no error

### DIFF
--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -74,6 +74,10 @@ func connectorCreate(d *schema.ResourceData, meta interface{}) error {
 		d.Set("config", newConfFiltered)
 	}
 
+	if err != nil {
+		return err
+	}
+
 	return connectorRead(d, meta)
 }
 
@@ -138,7 +142,6 @@ func connectorRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Current local config nonsensitive values are: %v", config)
 	//log.Printf("[INFO] Current local config_sensitive values are: %v", sensitiveCache)
 	conn, err := c.GetConnector(req)
-
 
 	if err == nil {
 		// we do not want the sensitive values to appear in the non-masked 'config' field


### PR DESCRIPTION
connectorCreate() can return error when there's a error and it shouldn't proceed to connectorRead() which returns no error.

 - https://github.com/Mongey/terraform-provider-kafka-connect/issues/25
 - https://github.com/Mongey/terraform-provider-kafka-connect/issues/26

There was an error but it wasn't handling it.

This pull request adds the ability to provide actual errors like below instead of "Error: Provider produced inconsistent result after apply"

```
2020/05/22 17:49:09 [DEBUG] kafka-connect_connector.test: apply errored, but we're indicating that via the Error pointer rather than returning it: Create connector : {"error_code":500,"message":"Not a valid JDBC URL: http://localhost:5432"}
```