### PR TITLE
connectorUpdate() shouldn't proceed to connectorRead() where there's an error otherwise prompt success despite unable to update

### DIFF
--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -126,6 +126,10 @@ func connectorUpdate(d *schema.ResourceData, meta interface{}) error {
 		d.Set("config_sensitive", sensitiveCache)
 	}
 
+	if err != nil {
+		return err
+	}
+
 	return connectorRead(d, meta)
 }
 


### PR DESCRIPTION
Like https://github.com/Mongey/terraform-provider-kafka-connect/pull/27, connectorUpdate() shouldn't proceed to connectorRead() where there's an error otherwise prompt success despite unable to update.

 - https://github.com/Mongey/terraform-provider-kafka-connect/issues/23

```
2020/05/25 16:03:16 [DEBUG] kafka-connect_connector.test: applying the planned Update change
2020/05/25 16:03:16 [INFO] Requesting update to connector sqlite-sink
2020/05/25 16:03:16 [INFO] Looking for sqlite-sink
2020/05/25 16:03:16 [DEBUG] kafka-connect_connector.test: apply errored, but we're indicating that via the Error pointer rather than returning it: Update connector : {"error_code":500,"message":"Not a valid JDBC URL: http://h2:8080"}
2020/05/25 16:03:16 [ERROR] <root>: eval: *terraform.EvalApplyPost, err: Update connector : {"error_code":500,"message":"Not a valid JDBC URL: http://h2:8080"}
2020/05/25 16:03:16 [ERROR] <root>: eval: *terraform.EvalSequence, err: Update connector : {"error_code":500,"message":"Not a valid JDBC URL: http://h2:8080"}
2020/05/25 16:03:16 [DEBUG] New state was assigned lineage "264e993b-83f4-4a1d-3f16-fe710f3ccd96"
    TestAccConnectorConfigUpdate: testing.go:568: Step 2 error: errors during apply:
        
        Error: Update connector : {"error_code":500,"message":"Not a valid JDBC URL: http://h2:8080"}
        
          on /tmp/tf-test579236420/main.tf line 2:
          (source code not available)
```

```
const testResourceConnector_initialConfig = `
resource "kafka-connect_connector" "test" {
  name = "sqlite-sink"

  config = {
		"name" = "sqlite-sink"
    "connector.class" = "io.confluent.connect.jdbc.JdbcSourceConnector"
    "tasks.max"       = "2"
    "topics"          = "orders"
    "connection.url"  = "jdbc:sqlite:test.db"
    "auto.create"     = "true"
    "topic.prefix" = "a"
    "mode" = "bulk"
  }
}
`

const testResourceConnector_updateConfig = `
resource "kafka-connect_connector" "test" {
  name = "sqlite-sink"

  config = {
		"name" = "sqlite-sink"
    "connector.class" = "io.confluent.connect.jdbc.JdbcSourceConnector"
    "tasks.max"       = "1"
    "topics"          = "orders"
    "connection.url"  = "http://h2:8080"
    "auto.create"     = "true"
    "topic.prefix" = "a"
    "mode" = "bulk"
  }
}
`
```

This pull request adds the ability to return error.

![image](https://user-images.githubusercontent.com/19510322/82815675-4b185d80-9ea2-11ea-9879-b6cbd0fa7887.png)
Before adding the changes in this pull request, it created inconsistency.