### PR TITLE
When config.name is not given in update or create, the resulting tfstate ends up to have inconsistency

### DIFF
--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -55,6 +56,11 @@ func connectorCreate(d *schema.ResourceData, meta interface{}) error {
 	name := nameFromRD(d)
 
 	config, sensitiveCache := configFromRD(d)
+	if n, ok := config["name"]; ok && n != name {
+		return errors.New("config.name must be identical to the resource name")
+	} else if !ok {
+		return errors.New("config.name is the mandatory field indentical to the resource name")
+	}
 
 	req := kc.CreateConnectorRequest{
 		ConnectorRequest: kc.ConnectorRequest{
@@ -105,6 +111,11 @@ func connectorUpdate(d *schema.ResourceData, meta interface{}) error {
 	name := nameFromRD(d)
 
 	config, sensitiveCache := configFromRD(d)
+	if n, ok := config["name"]; ok && n != name {
+		return errors.New("config.name must be identical to the resource name")
+	} else if !ok {
+		return errors.New("config.name is the mandatory field indentical to the resource name")
+	}
 
 	log.Printf("[INFO] Requesting update to connector %v", name)
 	req := kc.CreateConnectorRequest{


### PR DESCRIPTION
Problems to solve:
```
1. 2.
2020/05/25 15:53:05 [WARN] Provider "kafka-connect" produced an unexpected new value for kafka-connect_connector.test, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .config: new element "name" has appeared

3.
2020/05/25 17:23:59 [DEBUG] kafka-connect_connector.test: applying the planned Delete change
[INFO] Deleting the connector sqlite-sink
2020/05/25 17:23:59 [DEBUG] kafka-connect_connector.test: applying the planned Create change
[INFO] Created the connector error code: 0 , message: 
2020/05/25 17:23:59 [DEBUG] kafka-connect_connector.test: apply errored, but we're indicating that via the Error pointer rather than returning it: Create connector : {"error_code":400,"message":"Connector name configuration (sqlite-sink) doesn't match connector name in the URL (sqlite-sinka)"}
```

1. In the case that config.name is not given when create, it creates inconsistency as no plan is made to set config.name but the resulting tfstate has it with the resource name.
2. In the case that config.name is not given when update, plan makes changes "config.name abc => null" despite it doesn't update tfstate

3. In the case that config.name is provided but it is not identical to the resource name regardless of create or update, it kafka-connect server returns `{"error_code":400,"message":"Connector name configuration (sqlite-sink) doesn't match connector name in the URL (sqlite-sinka)"}`

This pull request adds the validation to check whether config.name is set or not and config.name is identical to the name of resource.


