### PR TITLE
Resource read should return API errors

### DIFF
--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -158,15 +158,17 @@ func connectorRead(d *schema.ResourceData, meta interface{}) error {
 	//log.Printf("[INFO] Current local config_sensitive values are: %v", sensitiveCache)
 	conn, err := c.GetConnector(req)
 
-	if err == nil {
-		// we do not want the sensitive values to appear in the non-masked 'config' field
-		// use cached sensitive values to get the correct keys to remove from the newly read config
-		newConfFiltered := removeSecondKeysFromFirst(conn.Config, sensitiveCache)
-		d.Set("config_sensitive", sensitiveCache)
-		d.Set("config", newConfFiltered)
-		log.Printf("[INFO] Local config nonsensitive data updated to %v", newConfFiltered)
-		//log.Printf("[INFO] Local config_sensitive data updated to %v", sensitiveCache)
+	if err != nil {
+		return err
 	}
+
+	// we do not want the sensitive values to appear in the non-masked 'config' field
+	// use cached sensitive values to get the correct keys to remove from the newly read config
+	newConfFiltered := removeSecondKeysFromFirst(conn.Config, sensitiveCache)
+	d.Set("config_sensitive", sensitiveCache)
+	d.Set("config", newConfFiltered)
+	log.Printf("[INFO] Local config nonsensitive data updated to %v", newConfFiltered)
+	//log.Printf("[INFO] Local config_sensitive data updated to %v", sensitiveCache)
 
 	return nil
 }


### PR DESCRIPTION

There's a bug in the error handling for `connectorRead()`. API errors on Connect calls are handled but the error isn't returned and propagated to the SDK, resulting in the framework assuming the read is successful. This has implications for `terraform plan` and `apply`.

on a plan, API errors on read are silently ignored, remote synchronisation fails and stale state is used present the diff:
```    
    kafka-connect_connector.psqlsource: Refreshing state... [id=customer.connector]
    2021-06-24T14:39:00.881+0100 [DEBUG] provider.terraform-provider-kafka-connect_v0.2.3: 2021/06/24 14:39:00 [INFO] Attempting to read remote data for connector customer.connector
    2021-06-24T14:39:00.881+0100 [DEBUG] provider.terraform-provider-kafka-connect_v0.2.3: 2021/06/24 14:39:00 [INFO] Current local config nonsensitive values are: map[auto.create:true connector.class:io.debezium.connector.postgresql.PostgresConnector database.dbname:customers database.hostname:postgres
    ...
    ...
    2021-06-24T14:39:11.723+0100 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/mongey/kafka-connect/0.2.3/linux_amd64/terraform-provider-kafka-connect_v0.2.3 pid=158158
    2021-06-24T14:39:11.723+0100 [DEBUG] provider: plugin exited
    
    Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
      ~ update in-place
    
    Terraform will perform the following actions:
    
      # kafka-connect_connector.psqlsource will be updated in-place
      ~ resource "kafka-connect_connector" "psqlsource" {
          ~ config           = {
              ~ "snapshot.mode"                  = "initial" -> "exported"
                # (22 unchanged elements hidden)
            }
            id               = "customer.connector"
            name             = "customer.connector"
            # (1 unchanged attribute hidden)
        }
    
    Plan: 0 to add, 1 to change, 0 to destroy.
```    

This also causes issues on an apply when update is called - the read incorrectly returns successful as above, even if the update fails and returns an error, due to the read swallowing the error, it updates the terraform state file as if the read had succeeded, producing an inconsistent state:

```
❯ terraform apply -auto-approve

kafka-connect_connector.psqlsource: Refreshing state... [id=customer.connector]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # kafka-connect_connector.psqlsource will be updated in-place
  ~ resource "kafka-connect_connector" "psqlsource" {
      ~ config           = {
          ~ "snapshot.mode"                  = "exported" -> "initial"
            # (22 unchanged elements hidden)
        }
        id               = "customer.connector"
        name             = "customer.connector"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
kafka-connect_connector.psqlsource: Modifying... [id=customer.connector]
kafka-connect_connector.psqlsource: Still modifying... [id=customer.connector, 10s elapsed]
╷
│ Error: Put http://localhost:8083/connectors/customer.connector/config: dial tcp 127.0.0.1:8083: connect: connection refused
│ 
│   with kafka-connect_connector.psqlsource,
│   on main.tf line 14, in resource "kafka-connect_connector" "psqlsource":
│   14: resource "kafka-connect_connector" "psqlsource" {
```

To avoid inconsistent state, the read should follow [best practice](https://www.terraform.io/docs/extend/best-practices/detecting-drift.html#error-checking-aggregate-types) and ensure API responses return an error e.g.:

```go
func resourceExampleSimpleRead(d *schema.ResourceData, meta interface{}) error {
   client := meta.(*ProviderApi).client
   resource, err := client.GetResource(d.Id())

   if err != nil {
      return fmt.Errorf("error getting resource %s: %s", d.Id(), err)
   }
   d.Set("name", resource.Name)
   d.Set("type", resource.Type)
   if err := d.Set("tags", resource.TagMap); err != nil {
      return fmt.Errorf("error setting tags for resource %s: %s", d.Id(), err)
   }
   return nil
   ```