### PR TITLE
Add m1 support to provider

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2
@@ -28,7 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           version: latest
           args: release --snapshot --rm-dist
-          key: ${{ secrets.YOUR_PRIVATE_KEY }}
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2
@@ -28,7 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --snapshot --rm-dist

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -17,10 +17,10 @@ jobs:
           go-version: 1.16.x
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v2
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       - run: make test
   acctest:
     runs-on: ubuntu-latest
@@ -23,9 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       - uses: actions/cache@v1
         with:
           path: ~/go/pkg/mod

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,9 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      - "--local-user"
-      - "A29F60D591A974E20B5E90695C886ACC44EB17C0"
+      - "--batch"
+      - "-u"
+      - "{{ .Env.GPG_FINGERPRINT }}"
       - "--output"
       - "${signature}"
       - "--detach-sign"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mongey/terraform-provider-kafka-connect
 
-go 1.12
+go 1.16
 
 require (
 	bou.ke/monkey v1.0.2 // indirect


### PR DESCRIPTION
Notable changes
- Upgraded GO version to 1.16
- Upgraded the GPG github action from v2 to v4
- Use the GPG_FINGERPRINT to sign the artifact checksums

Closes #43