### PR TITLE
Returning err when unable to delete connector

### DIFF
--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -98,9 +98,11 @@ func connectorDelete(d *schema.ResourceData, meta interface{}) error {
 	fmt.Printf("[INFO] Deleting the connector %s\n", name)
 
 	_, err := c.DeleteConnector(req, true)
-	if err == nil {
-		d.SetId("")
+	if err != nil {
+		return err
 	}
+
+	d.SetId("")
 
 	return nil
 }


### PR DESCRIPTION
Current Behaviour:
- When connector deletion fails, the destroy is marked as successful and state is removed
- When trying to recreate the connector, it fails due to existing connector in the cluster

Desired Behaviour: 
- When connector deletion fails, error is bubbled to terraform