### PR TITLE
Fix connector creation race condition causing 409 errors

### DIFF
--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -77,7 +77,14 @@ func connectorCreate(d *schema.ResourceData, meta interface{}) error {
 		Config: config,
 	}
 
-	connectorResponse, err := c.CreateConnector(req, true)
+	// Use retry logic for CreateConnector to handle race conditions
+	// where connector is created but GetConnector returns 409 if called too quickly
+	var connectorResponse kc.ConnectorResponse
+	err := withRebalanceRetry(func() error {
+		var createErr error
+		connectorResponse, createErr = c.CreateConnector(req, true)
+		return createErr
+	})
 
 	fmt.Printf("[INFO] Created the connector %v\n", connectorResponse)
 


### PR DESCRIPTION
in #90  users have reported that when creating a large number of connectors at once they receive a 409 response, this retry should help with that.