### PR TITLE
Always skip TLS verification when tls_auth_is_insecure is true

### DIFF
--- a/connect/provider.go
+++ b/connect/provider.go
@@ -90,15 +90,15 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	is_insecure := d.Get("tls_auth_is_insecure").(bool)
 	log.Printf("[INFO]Cert : %s\nKey: %s", crt, key)
 	log.Printf("[INFO]SSl connection is insecure : %t", is_insecure)
+	if is_insecure {
+		c.SetInsecureSSL()
+	}
 
 	if crt != "" && key != "" {
 		cert, err := tls.LoadX509KeyPair(crt, key)
 		if err != nil {
 			log.Fatalf("client: loadkeys: %s", err)
 		} else {
-			if is_insecure {
-				c.SetInsecureSSL()
-			}
 			c.SetClientCertificates(cert)
 		}
 	}


### PR DESCRIPTION
In the case where Kafka Connect is served with a self-signed certificate, but without client certificates, TLS verification should still be skipped (i.e. when `tls_auth_is_insecure = true`).

This moves the skip TLS verification block to always apply regardless of whether or not client certs are provided.

I believe this addresses #35 