### PR TITLE
feat: add resource kafka-connect_connector_status

### DIFF
--- a/connect/provider.go
+++ b/connect/provider.go
@@ -63,7 +63,8 @@ func Provider() *schema.Provider {
 		},
 		ConfigureContextFunc: providerConfigure,
 		ResourcesMap: map[string]*schema.Resource{
-			"kafka-connect_connector": kafkaConnectorResource(),
+			"kafka-connect_connector":        kafkaConnectorResource(),
+			"kafka-connect_connector_status": resourceKafkaConnectorStatus(),
 		},
 	}
 	log.Printf("[INFO] Created provider: %v", provider)

--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -200,51 +198,6 @@ func readWithRetry(d *schema.ResourceData, meta interface{}, timeout time.Durati
 	}, timeout)
 }
 
-// withRebalanceRetry executes the provided function with exponential backoff
-// retry logic specifically designed to handle Kafka Connect rebalancing
-// scenarios. The timeout parameter specifies how long to wait for rebalancing
-// to complete.
-func withRebalanceRetry(fn func() error, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	backoff := 250 * time.Millisecond
-	const maxBackoff = 5 * time.Second
-	for {
-		err := fn()
-		if err == nil {
-			return nil
-		}
-		if !isRebalanceError(err) {
-			return err
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out waiting for Kafka Connect rebalance to finish: %w", err)
-		}
-		jitter := time.Duration(rand.Int63n(int64(backoff / 2)))
-		sleep := backoff + jitter
-		log.Printf("[INFO] Connect rebalance in progress; retrying after %.2fs ... (%v)", sleep.Seconds(), err)
-		time.Sleep(sleep)
-		if backoff < maxBackoff {
-			backoff *= 2
-			if backoff > maxBackoff {
-				backoff = maxBackoff
-			}
-		}
-	}
-}
-
-// isRebalanceError tries to detect the Connect 409 window and related exceptions.
-func isRebalanceError(err error) bool {
-	msg := strings.ToLower(err.Error())
-	if strings.Contains(msg, "rebalance") ||
-		strings.Contains(msg, "rebalanceexpected") ||
-		strings.Contains(msg, "rebalance is expected") ||
-		strings.Contains(msg, "conflicting operation") {
-		return true
-	}
-
-	return strings.Contains(msg, "409")
-}
-
 // Returns a full config (inclusive of sensitive values) and a config of just the sensitive values
 // The first is intended to be passed to CreateConnectorRequest
 // The second is intended to preserve knowledge of which keys are sensitive information in the incoming
@@ -254,10 +207,6 @@ func configFromRD(d *schema.ResourceData) (map[string]interface{}, map[string]in
 	scfg := mapFromRD(d, "config_sensitive")
 	config := combineMaps(cfg, scfg)
 	return config, scfg
-}
-
-func nameFromRD(d *schema.ResourceData) string {
-	return d.Get("name").(string)
 }
 
 func mapFromRD(d *schema.ResourceData, key string) map[string]interface{} {

--- a/connect/resource_kafka_connector_status.go
+++ b/connect/resource_kafka_connector_status.go
@@ -1,0 +1,193 @@
+package connect
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	kc "github.com/ricardo-ch/go-kafka-connect/v3/lib/connectors"
+)
+
+const (
+	ConnectorStatusRunning    = "RUNNING"
+	ConnectorStatusPaused     = "PAUSED"
+	ConnectorStatusUnassigned = "UNASSIGNED"
+	ConnectorStatusFailed     = "FAILED"
+)
+
+func resourceKafkaConnectorStatus() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: CreateKafkaConnectorStatus,
+		ReadContext:   ReadKafkaConnectorStatus,
+		UpdateContext: UpdateKafkaConnectorStatus,
+		DeleteContext: DeleteKafkaConnectorStatus,
+		Importer: &schema.ResourceImporter{
+			StateContext: ImportKafkaConnectorStatus,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Second),
+			Update: schema.DefaultTimeout(60 * time.Second),
+			Delete: schema.DefaultTimeout(60 * time.Second),
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the connector",
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ConnectorStatusRunning,
+					ConnectorStatusPaused,
+				}, false),
+			},
+		},
+	}
+}
+
+func CreateKafkaConnectorStatus(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(kc.HighLevelClient)
+	connectorName := nameFromRD(d)
+	state := stateFromRD(d)
+
+	req := kc.ConnectorRequest{
+		Name: connectorName,
+	}
+
+	var err error
+	if state == ConnectorStatusRunning {
+		_, err = c.ResumeConnector(req, true)
+	} else if state == ConnectorStatusPaused {
+		_, err = c.PauseConnector(req, true)
+	} else {
+		return diag.Errorf("unknown desired state: %s. Can only set to %s or %s", state, ConnectorStatusRunning, ConnectorStatusPaused)
+	}
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Connector status changed to %s\n", state)
+
+	d.SetId(connectorName)
+	if err = d.Set("state", state); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return ReadKafkaConnectorStatus(ctx, d, meta)
+}
+
+func ReadKafkaConnectorStatus(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(kc.HighLevelClient)
+
+	name := nameFromRD(d)
+	req := kc.ConnectorRequest{
+		Name: name,
+	}
+
+	var connectorStatusResponse kc.GetConnectorStatusResponse
+	var err error
+	log.Printf("[INFO] Attempting to read status for connector %s", name)
+	if connectorStatusResponse, err = c.GetConnectorStatus(req); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if status := connectorStatusResponse.Code; status == 404 {
+		log.Printf("[WARN] Connector %s not found, removing from state", name)
+		d.SetId("")
+		return nil
+	}
+
+	if connectorState := connectorStatusResponse.ConnectorStatus["state"]; connectorState != "" {
+		switch connectorState {
+		case ConnectorStatusRunning:
+			err = d.Set("state", ConnectorStatusRunning)
+			log.Printf("[INFO] Connector state updated to %s", ConnectorStatusRunning)
+		case ConnectorStatusPaused:
+			err = d.Set("state", ConnectorStatusPaused)
+			log.Printf("[INFO] Connector state updated to %s", ConnectorStatusPaused)
+		case ConnectorStatusFailed:
+			err = d.Set("state", ConnectorStatusFailed)
+			log.Printf("[INFO] Connector is failing and will be registered as failed")
+		case ConnectorStatusUnassigned:
+			err = d.Set("state", ConnectorStatusRunning)
+			log.Printf("[INFO] Connector is unassigned and will be registered as running instead")
+		default:
+			log.Printf("[ERROR] Unknown connector status %s", connectorState)
+		}
+
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return nil
+}
+
+func UpdateKafkaConnectorStatus(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(kc.HighLevelClient)
+
+	connectorName := nameFromRD(d)
+
+	log.Printf("[INFO] Requesting update to connector status %s", connectorName)
+	req := kc.ConnectorRequest{
+		Name: connectorName,
+	}
+
+	var err error
+	if d.HasChange("state") {
+		pState, dState := d.GetChange("state")
+		previousState := pState.(string)
+		desiredState := dState.(string)
+
+		if desiredState == ConnectorStatusRunning && previousState == ConnectorStatusFailed {
+			log.Printf("[INFO] Attempting to restart connector %s", connectorName)
+			err = withRebalanceRetry(func() error {
+				_, err = c.RestartConnector(req)
+				return err
+			}, d.Timeout(schema.TimeoutUpdate))
+		} else if desiredState == ConnectorStatusRunning && previousState == ConnectorStatusPaused {
+			log.Printf("[INFO] Attempting to resume connector %s", connectorName)
+			_, err = c.ResumeConnector(req, true)
+		} else if desiredState == ConnectorStatusPaused {
+			log.Printf("[INFO] Pausing connector %s", connectorName)
+			_, err = c.PauseConnector(req, true)
+		}
+
+		if err != nil {
+			log.Printf("[ERROR] Failed to update connector status %s: %s", connectorName, err)
+			return diag.FromErr(err)
+		}
+
+		log.Printf("[INFO] Connector status changed to %s\n", desiredState)
+	}
+
+	return ReadKafkaConnectorStatus(ctx, d, meta)
+}
+
+func DeleteKafkaConnectorStatus(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Deleting status resource for connector '%s'; the connector itself will not be paused or resumed", d.Id())
+	d.SetId("")
+	return nil
+}
+
+func ImportKafkaConnectorStatus(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+
+	connectorName := d.Id()
+	log.Printf("[INFO] Importing connector status for: %s", connectorName)
+	if err := d.Set("name", connectorName); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func stateFromRD(d *schema.ResourceData) string {
+	return d.Get("state").(string)
+}

--- a/connect/resource_kafka_connector_status_test.go
+++ b/connect/resource_kafka_connector_status_test.go
@@ -1,0 +1,155 @@
+package connect
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	kc "github.com/ricardo-ch/go-kafka-connect/v3/lib/connectors"
+)
+
+var testAccProvider *schema.Provider
+var testAccProviderFactories map[string]func() (*schema.Provider, error)
+
+func init() {
+	testAccProvider = Provider()
+	testAccProviderFactories = map[string]func() (*schema.Provider, error){
+		"kafka-connect": func() (*schema.Provider, error) {
+			return testAccProvider, nil
+		},
+	}
+}
+
+func TestAccConnectorStatus_lifecycle(t *testing.T) {
+	var connectorName = "test-connector-lifecycle"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccConnectorCheckDestroy,
+		Steps: []resource.TestStep{
+			// Before starting, we need a connector to exist. This step is assumed to create it.
+			// In a real scenario, you would have a kafka-connect_connector resource here.
+			{
+				Config: testAccConnectorConfig_basic(connectorName),
+			},
+			// Step 1: Create status resource for the existing connector, set to RUNNING
+			{
+				Config: testAccConnectorStatusConfig(connectorName, ConnectorStatusRunning),
+				Check: resource.ComposeTestCheckFunc(
+					testAccConnectorStatusExists("kafka-connect_connector_status.test", ConnectorStatusRunning),
+					resource.TestCheckResourceAttr("kafka-connect_connector_status.test", "state", ConnectorStatusRunning),
+				),
+			},
+			// Step 2: Update status to PAUSED
+			{
+				Config: testAccConnectorStatusConfig(connectorName, ConnectorStatusPaused),
+				Check: resource.ComposeTestCheckFunc(
+					testAccConnectorStatusExists("kafka-connect_connector_status.test", ConnectorStatusPaused),
+					resource.TestCheckResourceAttr("kafka-connect_connector_status.test", "state", ConnectorStatusPaused),
+				),
+			},
+			// Step 3: Update status back to RUNNING
+			{
+				Config: testAccConnectorStatusConfig(connectorName, ConnectorStatusRunning),
+				Check: resource.ComposeTestCheckFunc(
+					testAccConnectorStatusExists("kafka-connect_connector_status.test", ConnectorStatusRunning),
+					resource.TestCheckResourceAttr("kafka-connect_connector_status.test", "state", ConnectorStatusRunning),
+				),
+			},
+		},
+	})
+}
+
+func testAccConnectorStatusExists(resourceName string, expectedStatus string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set for %s", resourceName)
+		}
+
+		client := testAccProvider.Meta().(kc.HighLevelClient)
+		connectorName := rs.Primary.ID
+
+		req := kc.ConnectorRequest{Name: connectorName}
+		status, err := client.GetConnectorStatus(req)
+		if err != nil {
+			return fmt.Errorf("error getting connector status for %s: %s", connectorName, err)
+		}
+
+		// The resource handles 404 by clearing the ID, but in an Exists check, a 404 is an error.
+		if status.Code == 404 || status.ConnectorStatus == nil {
+			return fmt.Errorf("connector '%s' not found on API", connectorName)
+		}
+
+		actualStatus := status.ConnectorStatus["state"]
+
+		// The resource treats UNASSIGNED as RUNNING, so we need to account for that in the check.
+		if expectedStatus == ConnectorStatusRunning && actualStatus == ConnectorStatusUnassigned {
+			return nil // This is an acceptable transient state.
+		}
+
+		if actualStatus != expectedStatus {
+			return fmt.Errorf("expected connector status to be '%s', but got '%s'", expectedStatus, actualStatus)
+		}
+
+		return nil
+	}
+}
+
+func testAccConnectorCheckDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "kafka-connect_connector" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(kc.HighLevelClient)
+		connectorName := rs.Primary.ID
+
+		req := kc.ConnectorRequest{Name: connectorName}
+		status, err := client.GetConnectorStatus(req)
+		if err != nil {
+			return fmt.Errorf("error getting connector status for %s: %s", connectorName, err)
+		}
+
+		// If it is found (not 404), is an error.
+		if status.Code != 404 {
+			return fmt.Errorf("connector '%s' still there after destroy", connectorName)
+		}
+	}
+	return nil
+}
+
+// Generates HCL for a kafka-connect_connector resource, needed as a prerequisite.
+func testAccConnectorConfig_basic(connectorName string) string {
+	return fmt.Sprintf(`
+resource "kafka-connect_connector" "test" {
+  name = "%s"
+
+  config = {
+    "name"            = "%s"
+    "connector.class" = "io.confluent.connect.jdbc.JdbcSinkConnector"
+    "tasks.max"       = "2"
+    "topics"          = "orders"
+    "connection.url"  = "jdbc:sqlite:test.db"
+    "auto.create"     = "true"
+  }
+}
+`, connectorName, connectorName)
+}
+
+// Generates HCL for the kafka-connect_connector_status resource.
+func testAccConnectorStatusConfig(connectorName string, state string) string {
+	// We depend on the connector existing first.
+	return testAccConnectorConfig_basic(connectorName) + fmt.Sprintf(`
+resource "kafka-connect_connector_status" "test" {
+  name  = kafka-connect_connector.test.name
+  state = "%s"
+}
+`, state)
+}

--- a/connect/utils.go
+++ b/connect/utils.go
@@ -1,0 +1,60 @@
+package connect
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// withRebalanceRetry executes the provided function with exponential backoff
+// retry logic specifically designed to handle Kafka Connect rebalancing
+// scenarios. The timeout parameter specifies how long to wait for rebalancing
+// to complete.
+func withRebalanceRetry(fn func() error, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	backoff := 250 * time.Millisecond
+	const maxBackoff = 5 * time.Second
+	for {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if !isRebalanceError(err) {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for Kafka Connect rebalance to finish: %w", err)
+		}
+		jitter := time.Duration(rand.Int63n(int64(backoff / 2)))
+		sleep := backoff + jitter
+		log.Printf("[INFO] Connect rebalance in progress; retrying after %.2fs ... (%v)", sleep.Seconds(), err)
+		time.Sleep(sleep)
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}
+
+// isRebalanceError tries to detect the Connect 409 window and related exceptions.
+func isRebalanceError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "rebalance") ||
+		strings.Contains(msg, "rebalanceexpected") ||
+		strings.Contains(msg, "rebalance is expected") ||
+		strings.Contains(msg, "conflicting operation") {
+		return true
+	}
+
+	return strings.Contains(msg, "409")
+}
+
+func nameFromRD(d *schema.ResourceData) string {
+	return d.Get("name").(string)
+}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -45,3 +45,8 @@ resource "kafka-connect_connector" "sqlite-sink-with-auth" {
     "connection.password" = "this-should-never-appear-unmasked"
   }
 }
+
+resource "kafka-connect_connector_status" "sqlite-sink" {
+  name  = kafka-connect_connector.sqlite-sink.name
+  state = "RUNNING"
+}


### PR DESCRIPTION
Feature request:
Add resource to manage connector status: `kafka-connect_connector_status`

According to https://docs.confluent.io/platform/current/connect/monitoring.html#connector-and-task-status, connector status can only be any of the following:
- UNASSIGNED
- RUNNING
- PAUSED
- FAILED

Hence this resource is intended to control connector to run (RUNNING) or stop (PAUSED) only. In case of other status:
- If connector is FAILED and we want it to run (RUNNING), connector will be restarted
- If connector is UNASSIGNED, we treat it as RUNNING status
- If connector is specified to stop (PAUSED), we trigger stop (PAUSED) from any connector actual status.

I think this is useful when we want to manage connector lifecycle via TF.