### PR TITLE
Mark delete operation as success when connector is not found

### DIFF
--- a/connect/resource_kafka_connector.go
+++ b/connect/resource_kafka_connector.go
@@ -114,6 +114,10 @@ func connectorDelete(d *schema.ResourceData, meta interface{}) error {
 
 	err := withRebalanceRetry(func() error {
 		_, derr := c.DeleteConnector(req, true)
+		if isNotFoundError(derr, name) {
+			log.Printf("[WARN] Connector %s does not exist. Marking deletion as a success.", name)
+			return nil
+		}
 		return derr
 	}, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
@@ -123,6 +127,18 @@ func connectorDelete(d *schema.ResourceData, meta interface{}) error {
 	d.SetId("")
 
 	return nil
+}
+
+// isNotFoundError tries to detect the 404 exception when a connector is not found.
+func isNotFoundError(err error, name string) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	notFoundError := fmt.Sprintf("connector %s not found", strings.ToLower(name))
+
+	return strings.Contains(msg, "404") && strings.Contains(msg, notFoundError)
 }
 
 func connectorUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/connect/resource_kafka_connector_test.go
+++ b/connect/resource_kafka_connector_test.go
@@ -167,6 +167,19 @@ func TestIsRebalanceError(t *testing.T) {
 	}
 }
 
+func TestIsNotFoundError(t *testing.T) {
+	notFoundError := errors.New("{\"error_code\":404,\"message\":\"Connector connector-name-example not found\"}")
+	connectorName := "connector-name-example"
+	if !isNotFoundError(notFoundError, connectorName) {
+		t.Errorf("expected 'not found' error to be detected")
+	}
+
+	normalErr := errors.New("connection timeout")
+	if isNotFoundError(normalErr, connectorName) {
+		t.Errorf("expected normal error to not be detected as a 'not found' error")
+	}
+}
+
 func TestWithRebalanceRetry(t *testing.T) {
 	t.Run("successful operation after rebalance errors", func(t *testing.T) {
 		callCount := 0


### PR DESCRIPTION
**Summary:** This makes the **destroy** operation idempotent for connectors. 

The provider now treats a connector deletion as a success when this connector does not exist.

Fixes #202 

## Context

Previously, a connector could be present in the tfstate but not exist in Connect. This could happen because of a manual deletion, or it could be the result of a partially failed terraform apply.

On a delete, the provider would fail to remove the connector, continuously retry for the timeout duration and finally output an error such as:
> │ Error: timed out waiting for Kafka Connect rebalance to finish: Delete connector : {"error_code":404,"message":"Connector XXX not found"}

This would require manually editing the state to fix the inconsistency.

A frequent cause of this issue are rebalances, which trigger when updating many connectors at once. Connect may apply some of the delete operations but fail to notify terraform, which leads to state inconsistency.

## Solution

This change ignores `Connector XXX not found` errors and marks the delete operation as a success instead.

Idempotence should improve the provider reliability as it will ensure the declared and actual state more closely match.

## Testing
- This has been tested manually on a connect instance
- A unit test has been added for the "not found error" detection